### PR TITLE
Minor comment fix in Windows build batch file

### DIFF
--- a/build_windows.bat
+++ b/build_windows.bat
@@ -13,7 +13,7 @@ set QT_VERSION=5.15.2
 set QT_COMPILER=msvc2019_%ARCH_BITS%
 set QT_BIN_DIR=%QT_DIR%\%QT_VERSION%\%QT_COMPILER%\bin
 
-# Download here https://cdn.flipperzero.one/STM32_DFU_USB_Driver.zip
+rem Download here https://cdn.flipperzero.one/STM32_DFU_USB_Driver.zip
 set STM32_DRIVER_DIR="C:\STM32 Driver"
 
 set QMAKE=%QT_BIN_DIR%\qmake.exe


### PR DESCRIPTION
When running the `build_windows.bat` script the following warning is emitted:

```
'#' is not recognized as an internal or external command,
```

The cause is that `#` isn't supported by batch files and `rem` should be used instead for comments