### PR TITLE
Enable VS Professional and Enterprise build environments

### DIFF
--- a/build_windows.bat
+++ b/build_windows.bat
@@ -1,12 +1,23 @@
 @echo off
+setlocal EnableDelayedExpansion
 
 set ARCH_BITS=64
 
 set MSVC_VERSION=2019
-set MSVC_DIR="%programfiles(x86)%\Microsoft Visual Studio\"%MSVC_VERSION%
+set "MSVC_DIR=%programfiles(x86)%\Microsoft Visual Studio\%MSVC_VERSION%"
 
 rem Import build environment
-call %MSVC_DIR%\"Community\VC\Auxiliary\Build\"vcvars%ARCH_BITS%.bat
+for %%s in (Community Professional Enterprise) do (
+    set "MSVC_VCVARS_PATH=%MSVC_DIR%\%%s\VC\Auxiliary\Build\vcvars%ARCH_BITS%.bat"
+    if exist !MSVC_VCVARS_PATH! (
+        goto foundmsvc
+    )
+)
+
+echo Could not find MSVC && goto error
+
+:foundmsvc
+call "!MSVC_VCVARS_PATH!"
 
 set QT_DIR=C:\Qt
 set QT_VERSION=5.15.2


### PR DESCRIPTION
Enable Windows build support using VS Professional and Enterprise build environments

This is done by looping through Community, Professional, and Enterprise and returning the first with an existing `VSVARS64.bat` file and invoking it. If the file isn't found in any of the folders, we exit with an error instead of continuing. 

For example, if only VS Professional is installed, it is now correctly invoked:
```
PS C:\Users\frosty\source\repos\qFlipper> .\build_windows.bat
**********************************************************************
** Visual Studio 2019 Developer Command Prompt v16.8.0
** Copyright (c) 2020 Microsoft Corporation
**********************************************************************
```
