### PR TITLE
Remove warning_message alias

### DIFF
--- a/setup_rules.sh
+++ b/setup_rules.sh
@@ -9,10 +9,10 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", ATTRS{manu
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", ATTRS{manufacturer}=="STMicroelectronics", TAG+="uaccess"
 '
 
-alias warning_message='printf "You will now be asked for SUDO password.\n"'
+
 
 rules_install() {
-    warning_message
+    printf "The installtion will now begin. Device rules will be configured on your systemt to communicate with your flipper!\n"
 
     # The danger zone
     if \

--- a/setup_rules.sh
+++ b/setup_rules.sh
@@ -12,7 +12,7 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", ATTRS{manu
 
 
 rules_install() {
-    printf "The installtion will now begin. Device rules will be configured on your systemt to communicate with your flipper!\n"
+    printf "The installtion will now begin. Device rules will be configured on your system to communicate with your flipper!\n"
 
     # The danger zone
     if \


### PR DESCRIPTION
When running the setup script the alias warning message terminates the setup from installing as the system believes the alias for the warning_message is an actual command. 

By removing the alias warning the script will continue the setup and make the necessary changes to for the Linux system to communicate with the flipper.