### PR TITLE
Comments on osx build and markdown linting (M1, arm64, building)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
-## qFlipper
+# qFlipper
 
-### Graphical desktop application for updating [Flipper Zero](https://flipperzero.one/) firmware via PC
+## Graphical desktop application for updating [Flipper Zero](https://flipperzero.one/) firmware via PC
+
 qFlipper is completely open source and based on [Qt](https://www.qt.io/) framework. Runs on Windows, macOS, Linux.
 
-<img alt="qFlipper" width="450" src="https://cdn.flipperzero.one/qflipper_logo_with_connected_flipper.png" />
+![qFlipper](https://cdn.flipperzero.one/qflipper_logo_with_connected_flipper.png "connect the flipperzero")
 
 ## Download
 
 Download official qFlipper builds here: [update.flipperzero.one](https://update.flipperzero.one/)
 
-<a href="https://update.flipperzero.one"><img width="300" alt="download qFlipper Button" src="https://cdn.flipperzero.one/download_qFlipper_button.png" /></a>
-
+[<img width="300" alt="download qFlipper Button" src="https://cdn.flipperzero.one/download_qFlipper_button.png" />](https://update.flipperzero.one)
 
 ## Features
+
 * Update Flipper's firmware and supplemental data with a press of one button
 * Repair a broken firmware installation
 * Stream Flipper's display and control it remotely
@@ -21,20 +22,26 @@ Download official qFlipper builds here: [update.flipperzero.one](https://update.
 * Automatic self-update feature
 * Command line interface
 
-## Build from sources 
+## Build from sources
+
 ### Cloning
-Make sure to clone the project together with submodules: 
+
+Make sure to clone the project together with submodules:
+
 ```sh
 git clone https://github.com/flipperdevices/qFlipper.git --recursive
 ```
+
 ### Windows
 
 Build requirements:
-- MS Visual Studio 2019 or newer
-- Qt (MSVC build) >= 5.15.0
-- NSIS (to generate the installer)
+
+* MS Visual Studio 2019 or newer
+* Qt (MSVC build) >= 5.15.0
+* NSIS (to generate the installer)
 
 Edit `build_windows.bat` to adjust to your build environment and then run:
+
 ```cmd
 build_windows.bat
 ```
@@ -42,74 +49,90 @@ build_windows.bat
 Note: STM32 Bootloader driver is not provided in this repository.
 
 ### Linux
+
 #### Docker build (AppImage, official)
 
 ```sh
+docker-compose up -d
 docker-compose exec dev ./build_linux.sh
 ```
 
 #### Standalone build
+
 Build requirements:
-- Qt >= 5.15.0
-- libusb >= 1.0.16
+
+* Qt >= 5.15.0
+* libusb >= 1.0.16
+
 ```sh
 mkdir build && cd build
-qmake ../qFlipper.pro PREFIX=/path/to/install/dir -spec linux-g++ CONFIG+=qtquickcompiler && 
+qmake ../qFlipper.pro PREFIX=/path/to/install/dir -spec linux-g++ CONFIG+=qtquickcompiler &&
 make qmake_all && make && make install
 ```
-**Caution:** `make install`ing to the system prefix is not recommended. Instead, use this method for building distro-specific packages. 
+
+**Caution:** `make install`ing to the system prefix is not recommended. Instead, use this method for building distro-specific packages.
 In this case, it is possible to disable the built-in application update feature by passing `DEFINES+=DISABLE_APPLICATION_UPDATES` to the `qmake` call.
 
 ### MacOS
 
 Build requirements:
 
-- Xcode or command line tools
-- Qt >= 5.15.0
-- libusb
+* Xcode or command line tools
+* Qt >= 5.15.0 # not compatible with 6.X
+* [libusb/libusb](https://github.com/libusb/libusb)
+* [create-dmg/create-dmg](https://github.com/create-dmg/create-dmg)
 
 If you want to sign binaries, set `SIGNING_KEY` environment variable:
 
-	export SIGNING_KEY="Your Developer Key ID"
+```sh
+export SIGNING_KEY="Your Developer Key ID"
+```
 
 Building, signing and creating package:
 
-	./build_mac.sh
+```sh
+./build_mac.sh
+```
 
 Resulting image can be found in: `build_mac/qFlipper.dmg`
 
 ## Run
 
-### Linux
+### Run on Linux
+
 ```sh
 ./build/qFlipper-x86_64.AppImage
 ```
 
 or just launch the file above from your favourite file manager.
 You will likely need to set up udev rules in order to use qFlipper as a normal user:
+
 ```sh
 ./qFlipper-x86_64.AppImage rules install [/optional/path/to/rules/dir]
 ```
 
 #### Package managers support
+
 See [contrib](./contrib) for available options.
 
 ## Project structure
-- `application` - The main graphical application, written mostly in QML.
-- `cli` - The command line interface, provides nearly all main application's functionality.
-- `backend` - The backend library, written in C++. Takes care of most of the logic.
-- `dfu` - Low level library for accessing USB and DFU devices.
-- `plugins` - Protobuf-based communication protocol support.
-- `3rdparty` - Third-party libraries.
-- `contrib` - Contributed packages and scripts.
-- `driver-tool` - DFU driver installation tool for Windows (based on `libwdi`).
-- `docker` - Docker configuration files.
-- `installer-assets` - Supplementary data for deployment.
+
+* `application` - The main graphical application, written mostly in QML.
+* `cli` - The command line interface, provides nearly all main application's functionality.
+* `backend` - The backend library, written in C++. Takes care of most of the logic.
+* `dfu` - Low level library for accessing USB and DFU devices.
+* `plugins` - Protobuf-based communication protocol support.
+* `3rdparty` - Third-party libraries.
+* `contrib` - Contributed packages and scripts.
+* `driver-tool` - DFU driver installation tool for Windows (based on `libwdi`).
+* `docker` - Docker configuration files.
+* `installer-assets` - Supplementary data for deployment.
 
 ## Reporting bugs
+
 qFlipper is a project under active development. Please report any encountered bugs to make it better!
 
-The (mostly) complete guide is located [here](./BUGS.md).
+Fill in the template from issues [here](https://github.com/flipperdevices/qFlipper/issues/new?assignees=&labels=bug&template=bug_report.md&title=).
 
 ## Known bugs
 

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,4 +1,5 @@
 # Contributed packages
+
 This directory contains community-contributed files for various package management systems. None of them were tested by Flipper QA.
 
 For each system, see the respective subdirectory.

--- a/contrib/nix/README.md
+++ b/contrib/nix/README.md
@@ -1,13 +1,12 @@
 # Nix packaging for qFlipper
 
-
 ## Building
 
 __Check that you have at least Nix 2.6.__
 
 You can build qFlipper via Nix with one command.
 
-```
+```sh
 nix build --experimental-features "nix-command flakes" 'github:flipperdevices/qFlipper?dir=contrib/nix&submodules=1'
 ```
 
@@ -15,8 +14,7 @@ For simplicity, I will leave out `--experimental-features "nix-command flakes"` 
 
 If you wish to use a different version of qFlipper, just specify the commit hash or revision after the repo path.
 
-
-```
+```sh
 nix build 'github:flipperdevices/qFlipper/COMMIT_HASH_OR_REVISION?dir=contrib/nix&submodules=1'
 ```
 
@@ -29,7 +27,8 @@ Built binaries will be located in `./result/bin` folder.
 Run `nix develop 'contrib/nix?submodules=1'`
 This will drop you in the shell with all required build dependencies.
 After this, you can proceed as usual:
-```
+
+```sh
 mkdir build
 cd build
 qmake ..
@@ -39,10 +38,11 @@ make -j30
 You may also need to run `makeQtWrapper ./binary ./wrapper` on built binaries to generate wrapper shell script,
 which would load all the required QT environment variables.
 
-
 ### Enabling flakes
+
 If you wish to never again write `--experimental-features "nix-command flakes"`:
-```
+
+```sh
 mkdir -p ~/.config/nix
 echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   dev:
     build: docker
+    platform: linux/amd64
     network_mode: "host"
     privileged: true
     tty: true


### PR DESCRIPTION
This change fixes most of the warnings shown by [markdownlint](https://github.com/DavidAnson/vscode-markdownlint) from the `README.md` and `contrib/README.md`.

```sh
markdownlint README.md 2>&1 |wc -l
      66
```
after the adjustments there are `10` warnings all related to line length:

```sh
markdownlint README.md 2>&1 |wc -l             
      10 
```

It also does add one missing dependency when building on OSX (`create-dmg`) and a comment about `qt@6` not being compatible yet, I've seen #69 which might fix this problem.

There is one more change which is "forced" architecture when using docker-compose to prevent trying to build with different than supported architecture `linux/amd64`, otherwise packages will fail to be found and installed.