### PR TITLE
Fix padding for 32 bit builds (Fixes #120)

### DIFF
--- a/dfu/device/stm32wb55/infotable.h
+++ b/dfu/device/stm32wb55/infotable.h
@@ -52,6 +52,7 @@ struct FUSDeviceInfoTable
     uint32_t  reserved2;
     uint64_t  UID64;
     uint16_t  deviceID;
+    uint32_t  padding_ /* padding for 32 bits build */;
 };
 
 struct DeviceInfoTable {


### PR DESCRIPTION
I incorporated this patch into the Debian builds and also did a successful firmware update using the 32 bit build.