### PR TITLE
Don't use time_t for timestamps

### DIFF
--- a/backend/flipperzero/assetmanifest.cpp
+++ b/backend/flipperzero/assetmanifest.cpp
@@ -36,7 +36,7 @@ int AssetManifest::version() const
     return m_version;
 }
 
-time_t AssetManifest::timestamp() const
+qint64 AssetManifest::timestamp() const
 {
     return m_timestamp;
 }

--- a/backend/flipperzero/assetmanifest.h
+++ b/backend/flipperzero/assetmanifest.h
@@ -25,7 +25,7 @@ public:
     AssetManifest(const QByteArray &text);
 
     int version() const;
-    time_t timestamp() const;
+    qint64 timestamp() const;
     FileNode *tree() const;
 
 private:
@@ -36,7 +36,7 @@ private:
     bool parseDirectory(const QStringList &tokens);
 
     int m_version;
-    time_t m_timestamp;
+    qint64 m_timestamp;
     QSharedPointer<FileNode> m_root;
 };
 

--- a/backend/flipperzero/factoryinfo.cpp
+++ b/backend/flipperzero/factoryinfo.cpp
@@ -204,7 +204,7 @@ void FactoryInfo::parseV2(const QByteArray &data)
     m_region = (Region)otp->region;
 }
 
-time_t FactoryInfo::date() const
+qint64 FactoryInfo::date() const
 {
     return m_date;
 }

--- a/backend/flipperzero/factoryinfo.h
+++ b/backend/flipperzero/factoryinfo.h
@@ -23,7 +23,7 @@ public:
     uint8_t target() const;
     uint8_t body() const;
     uint8_t connect() const;
-    time_t date() const;
+    qint64 date() const;
 
     const QString &name() const;
 
@@ -44,7 +44,7 @@ private:
     uint8_t m_target;
     uint8_t m_body;
     uint8_t m_connect;
-    time_t m_date;
+    qint64 m_date;
     QString m_name;
 
     Color m_color;

--- a/backend/flipperzero/radiomanifest.cpp
+++ b/backend/flipperzero/radiomanifest.cpp
@@ -32,7 +32,7 @@ RadioManifest::Header::Header(const QJsonValue &json)
     }
 
     if(obj.contains(QStringLiteral("timestamp"))) {
-        m_timestamp = (time_t)obj.value(QStringLiteral("timestamp")).toInt();
+        m_timestamp = obj.value(QStringLiteral("timestamp")).toInt();
     } else {
         throw std::runtime_error("Failed to read manifest timestamp");
     }
@@ -43,7 +43,7 @@ int RadioManifest::Header::version() const
     return m_version;
 }
 
-time_t RadioManifest::Header::timestamp() const
+qint64 RadioManifest::Header::timestamp() const
 {
     return m_timestamp;
 }

--- a/backend/flipperzero/radiomanifest.h
+++ b/backend/flipperzero/radiomanifest.h
@@ -19,11 +19,11 @@ public:
         Header(const QJsonValue &json);
 
         int version() const;
-        time_t timestamp() const;
+        qint64 timestamp() const;
 
     private:
         int m_version;
-        time_t m_timestamp;
+        qint64 m_timestamp;
     };
 
     class Condition {


### PR DESCRIPTION
I believe time_t is coming in via header pollution on some platforms (and not others where there is a compile error for the missing type), but it also can vary between 32 and 64 bits depending on the platform.  Use a qint64 instead since it has nothing to do with ctime.