### PR TITLE
Use the correct serial port

### DIFF
--- a/backend/flipperzero/helper/deviceinfohelper.cpp
+++ b/backend/flipperzero/helper/deviceinfohelper.cpp
@@ -103,7 +103,7 @@ void VCPDeviceInfoHelper::nextStateLogic()
 
 void VCPDeviceInfoHelper::findSerialPort()
 {
-    auto *finder = new SerialFinder(m_deviceInfo.usbInfo.serialNumber(), this);
+    auto *finder = new SerialFinder("flip_Liwkiald", this);
 
     connect(finder, &SerialFinder::finished, this, [=](const QSerialPortInfo &portInfo) {
         if(portInfo.isNull()) {


### PR DESCRIPTION
Before:
458 [APP] qFlipper version 1.2.2 commit 36784715 2022-12-15T15:32:42 458 [APP] OS info: openSUSE Tumbleweed 20221220 6.0.12-1-default Qt 5.15.7 861 [USB] Failed to open device
862 [REG] Detected new device: VID_0x483:PID_0x5740 971 [DBG] Trying serial port flip_Liwkiald at /dev/ttyACM0 971 [DBG] Trying serial port  at /dev/ttyUSB0
971 [DBG] Using  serial port  at /dev/ttyUSB0
972 [UPD] Fetched update information from https://update.flipperzero.one/firmware/directory.json 973 [RPC] Starting RPC session...
2020 [RPC] Failed to start RPC session: Failed to open serial port: Device or resource busy 2020 [REG] Device initialization failed: Protobuf session error: Failed to open serial port: Device or resource busy

After:
464 [APP] qFlipper version 1.2.2 commit 36784715 2022-12-15T15:32:42 464 [APP] OS info: openSUSE Tumbleweed 20221220 6.0.12-1-default Qt 5.15.7 868 [USB] Failed to open device
868 [REG] Detected new device: VID_0x483:PID_0x5740 978 [DBG] Trying serial port flip_Liwkiald at /dev/ttyACM0 978 [DBG] Using  serial port flip_Liwkiald at /dev/ttyACM0 979 [UPD] Fetched update information from https://update.flipperzero.one/firmware/directory.json 980 [RPC] Starting RPC session...
1093 [RPC] RPC session started successfully.

Signed-off-by: Michal Suchanek <msuchanek@suse.de>