### PR TITLE
Fix zero width window

### DIFF
--- a/application/main.qml
+++ b/application/main.qml
@@ -11,6 +11,7 @@ Window {
     flags: Qt.Window | Qt.FramelessWindowHint | Qt.NoDropShadowWindowHint
     title: Qt.application.displayName
 
+    width: mainWindow.baseWidth + mainWindow.shadowSize * 2
     height: mainWindow.baseHeight + mainWindow.shadowSize * 2
 
     minimumWidth: mainWindow.baseWidth + mainWindow.shadowSize * 2


### PR DESCRIPTION
Under some window managers the window width is zero when not set by the application.

Signed-off-by: Michal Suchanek <msuchanek@suse.de>