### PR TITLE
Fix tgz name and subfolder name mismatch (Cannot find update directory)

### DIFF
--- a/backend/flipperzero/toplevel/fullupdateoperation.cpp
+++ b/backend/flipperzero/toplevel/fullupdateoperation.cpp
@@ -312,7 +312,7 @@ bool FullUpdateOperation::findAndCdToUpdateDir()
         const auto &fileInfo = it.fileInfo();
         const auto fileName = fileInfo.fileName();
 
-        if(fileInfo.isDir() && m_updateDirectory.dirName().endsWith(fileName)) {
+        if(fileInfo.isDir()) {
             m_updateDirectory.cd(fileName);
             return true;
         }


### PR DESCRIPTION
This aims to fix the `Cannot find update directory` error when installing with `Install from file`.

The current logic extracts the tgz file, then `cd`'s into its subfolder by checking against the tgz filename on said subfolder. This can cause many issues with `Install from file` because if for whatever reason the tgz file itself was renamed, the update will fail. In particular this can be seen with browser downloads, where downloading multiple times, perhaps by accident, adds a `(1)` to the filename, which will then make the tgz unusable for `Install from file`.

This fix mimics the mobile apps behavior (from what I can tell), where after extracting, the first subdirectory of the tgz is chosen, regardless of naming. If no subdirectory is found, the same error will be thrown.

I understand that there may be some security concerns with this, but frankly a simple filename comparison seems to me like the wrong way to implement a security check in this case, and it instead just creates many opportunities for user "error" (more like unexpected behavior).