### PR TITLE
Replace alias with a proper variable usage

### DIFF
--- a/setup_rules.sh
+++ b/setup_rules.sh
@@ -11,10 +11,10 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", ATTRS{manu
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="303a", ATTRS{idProduct}=="40??", ATTRS{manufacturer}=="Flipper Devices Inc.", TAG+="uaccess"
 '
 
-alias warning_message='printf "You will now be asked for SUDO password.\n"'
+warning_message="You will now be asked for SUDO password.\n"
 
 rules_install() {
-    warning_message
+    printf "$warning_message"
 
     # The danger zone
     if \
@@ -32,7 +32,7 @@ rules_install() {
 
 rules_uninstall() {
     if [ -f "$RULES_FILE" ]; then
-        warning_message
+        printf "$warning_message"
 
         # The danger zone
         if


### PR DESCRIPTION
Modern Linux systems will symlink /bin/sh to either /bin/bash or /bin/dash (in the case of Ubuntu). 
These shell environments do not allow for the usage of `alias` within scripts, and results in an error when this script is run directly. 

I have instead replaced it with a proper shellscript variable usage, eliminating the need for `alias` entirely.  

changes tested across Fedora, Arch, and Ubuntu without issue. 