### PR TITLE
Added AppStream metainfo XML annoucing supported hardware.

### DIFF
--- a/application/application.pro
+++ b/application/application.pro
@@ -112,7 +112,10 @@ unix:!macx {
     udevfiles.files = $$PWD/../installer-assets/udev/42-flipperzero.rules
     udevfiles.path = $$PREFIX/lib/udev/rules.d
 
-    INSTALLS += target desktopfiles iconfiles udevfiles
+    meta.path = /usr/share/metainfo
+    meta.files += one.flipperzero.qflipper.metainfo.xml
+
+    INSTALLS += target desktopfiles iconfiles udevfiles meta
 
 } else:win32 {
     target.path = $$DESTDIR/$$NAME

--- a/application/one.flipperzero.metainfo.xml
+++ b/application/one.flipperzero.metainfo.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>one.flipperzero</id>
+  <metadata_license>MIT</metadata_license>
+  <name>qflipper</name>
+  <summary>Flipper Zero firmware updater</summary>
+  <description>
+    <p>qFlipper is a desktop application for updating Flipper Zero
+    firmware.</p>
+    <p>Features include:</p>
+    <ul>
+      <li>Update Flipper's firmware and supplemental data with a press
+      of one button</li>
+      <li>Repair a broken firmware installation</li>
+      <li>Stream Flipper's display and control it remotely</li>
+      <li>Install firmware from a .dfu file</li>
+      <li>Backup and restore settings, progress and pairing data</li>
+      <li>Command line interface</li>
+    </ul>
+  </description>
+  <launchable type="desktop-id">qFlipper.desktop</launchable>
+  <provides>
+    <modalias>usb:v0483p5740d*</modalias>
+    <modalias>usb:v0483pDF11d*</modalias>
+    <modalias>usb:v303Ap40??d*</modalias>
+  </provides>
+</component>


### PR DESCRIPTION
Including this information in the package will ensure programs mapping hardware to packages using Appstream information, like the isenkram package, will know that this package is useful on machines where the USB IDs are discovered.

This is also reported as <URL: https://bugs.debian.org/1071077 >.